### PR TITLE
refactor: increase the limit of PRs being opened by dependabot in parallel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   # Daily: Check minor and patch updates
   - package-ecosystem: 'npm'
     directory: '/'
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 10
     schedule:
       interval: 'weekly'
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
   # Daily: Check minor and patch updates
   - package-ecosystem: 'npm'
     directory: '/'
+    open-pull-requests-limit: 0
     schedule:
       interval: 'weekly'
     ignore:


### PR DESCRIPTION
> `open-pull-requests-limit`
> By default, Dependabot opens a maximum of five pull requests for version updates. Once there are five open pull requests from Dependabot, Dependabot will not open any new requests until some of those open requests are merged or closed. Use open-pull-requests-limit to change this limit. This also provides a simple way to temporarily disable version updates for a package manager.

> This option has no impact on security updates, which have a separate, internal limit of ten open pull requests.

_source: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit_


currently dependabot doesn't open any new PRs if the amount of open PRs by dependabot (currently 5) is even already reached. Especially within the Elements repo we might have some more PRs open, especially regarding major framework updates (and dependabot even also doesn't support grouping related dependencies so far, so the problem might even further increase), which would lead to that dependabot silently skips until the next cycle to analyse for new updates.
We might even also be able to deactivate this limit in total, but I still like the idea to at least limit it to around 10 or so, and work with a daily check for new updates.

_similar to https://github.com/db-ui/base/pull/49 and https://github.com/db-ui/core/pull/51_