### PR TITLE
docs(icon): font-size overwrites

### DIFF
--- a/packages/db-ui-elements-stencil/src/components/db-icon/readme.md
+++ b/packages/db-ui-elements-stencil/src/components/db-icon/readme.md
@@ -13,6 +13,7 @@
 | `variant`           | `variant` | The variant attribute specifies the style and size of an icon. | `"16-filled" \| "16-outline" \| "20-filled" \| "20-outline" \| "24-filled" \| "24-outline" \| "32-filled" \| "32-outline" \| "48-filled" \| "48-outline" \| "64-filled" \| "64-outline"` | `undefined` |
 
 ## CSS Custom Properties
+
 | Property                  | Description                                               |
 | ------------------------- | --------------------------------------------------------- |
 | `--icon-font-size-before` | Overwrite `font-size` by the icon set before the contents |

--- a/packages/db-ui-elements-stencil/src/components/db-icon/readme.md
+++ b/packages/db-ui-elements-stencil/src/components/db-icon/readme.md
@@ -12,6 +12,12 @@
 | `icon` _(required)_ | `icon`    | The icon attribute specifies the icon to use.                  | `string`                                                                                                                                                                                 | `undefined` |
 | `variant`           | `variant` | The variant attribute specifies the style and size of an icon. | `"16-filled" \| "16-outline" \| "20-filled" \| "20-outline" \| "24-filled" \| "24-outline" \| "32-filled" \| "32-outline" \| "48-filled" \| "48-outline" \| "64-filled" \| "64-outline"` | `undefined` |
 
+## CSS Custom Properties
+| Property                  | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| `--icon-font-size-before` | Overwrite `font-size` by the icon set before the contents |
+| `--icon-font-size-after`  | Overwrite `font-size` by the icon set after the contents  |
+
 
 ## Dependencies
 


### PR DESCRIPTION
Resolves https://github.com/db-ui/elements/issues/1166

It's now possible to overwrite the icons `font-size` selectively for the icon before or after the content via a CSS Custom Property:
- `--icon-font-size-before`
- `--icon-font-size-after`