### PR TITLE
refactor: preventing the need for some dependencies updates approvals

### DIFF
--- a/.github/workflows/00-scan-secrets.yml
+++ b/.github/workflows/00-scan-secrets.yml
@@ -17,7 +17,7 @@ jobs:
         id: extract_branch
 
       - name: 🐷 TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.39.0
+        uses: trufflesecurity/trufflehog@v3
         with:
           path: ./
           base: ${{ steps.extract_branch.outputs.branch-name }}


### PR DESCRIPTION
As we use this dependency only within our GitHub Action but not within any JavaScript, it's easy not to pin it to a minor or even patch version, but only major.