### PR TITLE
refactor(dependabot): prevent further angular major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/animations'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@angular-devkit/build-angular'
+        update-types: ['version-update:semver-major']
     pull-request-branch-name:
       separator: '-'
     # https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular-devkit/build-angular'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/platform-browser'
+        update-types: ['version-update:semver-major']
     pull-request-branch-name:
       separator: '-'
     # https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437


### PR DESCRIPTION
We're only updating Angular major versions manually.