### PR TITLE
refactor: removed obsolete npm engine restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,8 +87,5 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "homepage": "https://db-ui.github.io/elements/",
-  "engines": {
-    "npm": "^8.1.0"
-  }
+  "homepage": "https://db-ui.github.io/elements/"
 }


### PR DESCRIPTION
I can't identify a reason why we would still need to restrict (and frequently update) the npm engines version for our repository.