### PR TITLE
refactor(dependabot): Angular 14 dependency zone.js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,9 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/platform-browser-dynamic'
         update-types: ['version-update:semver-major']
+      # Angular 14 only works with zone.js 0.11.x
+      - dependency-name: 'zone.js'
+        update-types: ['version-update:semver-minor']
     pull-request-branch-name:
       separator: '-'
   - package-ecosystem: 'npm'


### PR DESCRIPTION
We need to prevent `zone.js` dependency minor updates for Angular 14 due to pipeline problems with newer versions:
https://github.com/db-ui/elements/actions/runs/6295775406/job/17089758599?pr=1779