### PR TITLE
fix: jsdom types error coming up through stenciljs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint:stylelint": "stylelint **/*.scss",
     "lint:eslint": "eslint . --ext .ts,.js --ignore-path .gitignore  --ignore-path .eslintignore && npm run lint --workspace=@db-ui/elements",
     "generate": "npm run generate --workspace=@db-ui/elements",
-    "clean": "git clean -dfx --exclude=.env"
+    "clean": "git clean -dfx --exclude=.env",
+    "postinstall": "node ./build/ci/postInstall.js"
   },
   "workspaces": [
     "packages/*"

--- a/package.md
+++ b/package.md
@@ -6,6 +6,7 @@
 * *release*: runs [`np`](https://www.npmjs.com/package/np) to support the release process
 * *start*: starts both a `stencil` build watcher as well as the *storybook* script
 * *clean*: cleaning your working copy, but leave relevant files like e.g. your `.env` file untouched
+* *postinstall*: some scripts that you should run after installing node packages via npm
 
 ## devDependencies
 

--- a/scripts/postInstall.js
+++ b/scripts/postInstall.js
@@ -1,0 +1,38 @@
+// adapted from https://github.com/microsoft/vscode-jupyter/pull/7987
+const { EOL } = require('node:os');
+const path = require('node:path');
+const fs = require('fs-extra');
+
+/**
+ * Fix compilation issues in jsdom files.
+ */
+function updateJSDomTypeDefinition() {
+  var relativePath = path.join('node_modules', '@types', 'jsdom', 'base.d.ts');
+  var filePath = path.join('./', relativePath);
+  if (!fs.existsSync(filePath)) {
+    console.warn(
+      "JSdom base.d.ts not found '" +
+        filePath +
+        "' (Jupyter Extension post install script)"
+    );
+    return;
+  }
+  var fileContents = fs.readFileSync(filePath, { encoding: 'utf8' });
+  var replacedContents = fileContents.replace(
+    /\s*globalThis: DOMWindow;\s*readonly \["Infinity"]: number;\s*readonly \["NaN"]: number;/g,
+    [
+      'globalThis: DOMWindow;',
+      '// @ts-ignore',
+      'readonly ["Infinity"]: number;',
+      '// @ts-ignore',
+      'readonly ["NaN"]: number;'
+    ].join(`${EOL}        `)
+  );
+  if (replacedContents === fileContents) {
+    console.warn('JSdom base.d.ts not updated');
+    return;
+  }
+  fs.writeFileSync(filePath, replacedContents);
+}
+
+updateJSDomTypeDefinition();


### PR DESCRIPTION
Resolves https://github.com/db-ui/elements/issues/2094

Most likely we can't make this run after installing node packages via `npm i` automatically, as this event / hook has been disabled by `npm` and you would need to run it manually in case of experiencing the same problem described in the related ticket https://github.com/db-ui/elements/issues/2094.