### PR TITLE
chore(dependabot): added dependencies to the `major` update ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,6 +127,10 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/core'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/compiler-cli'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/router'
+        update-types: ['version-update:semver-major']
       - dependency-name: '@angular/compiler'
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/common'
@@ -155,6 +159,10 @@ updates:
       - dependency-name: '@angular/core'
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/compiler'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/compiler-cli'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/router'
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/common'
         update-types: ['version-update:semver-major']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/cli'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/compiler-cli'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'jest-cli'
         update-types: ['version-update:semver-major']
       # Stencil only supports jest version 27 at the moment

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/compiler-cli'
         update-types: ['version-update:semver-major']
+      - dependency-name: '@angular-devkit/build-angular'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@angular/router'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'jest-cli'
         update-types: ['version-update:semver-major']
       # Stencil only supports jest version 27 at the moment

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,8 +24,6 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/compiler-cli'
         update-types: ['version-update:semver-major']
-      - dependency-name: '@angular-devkit/build-angular'
-        update-types: ['version-update:semver-major']
       - dependency-name: '@angular/router'
         update-types: ['version-update:semver-major']
       - dependency-name: 'jest-cli'
@@ -136,6 +134,8 @@ updates:
       - dependency-name: '@angular/forms'
         update-types: ['version-update:semver-major']
       - dependency-name: '@angular/platform-browser-dynamic'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@angular-devkit/build-angular'
         update-types: ['version-update:semver-major']
     pull-request-branch-name:
       separator: '-'


### PR DESCRIPTION
So that it doesn't open major updates PRs for these Angular dependencies.