### PR TITLE
chore: updated `actions/setup-node` and `actions/cache`

### DIFF
--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Setup node equally to our local development version
       # pick the Node version to use and install it
       # https://github.com/actions/setup-node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 20
 

--- a/.github/actions/npm-cache/action.yml
+++ b/.github/actions/npm-cache/action.yml
@@ -30,7 +30,7 @@ runs:
         node --version
         npm --version
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: 'cache'
       with:
         path: ${{ inputs.nodeModulesPath }}


### PR DESCRIPTION
Updated https://github.com/actions/setup-node and https://github.com/actions/cache to a new major versions. Mainly the supported minimum Node version has been changed to Node 20.