### PR TITLE
refactor: update husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit "$1"
+commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,6 @@
+echo "### npm run general lintings ###"
+concurrently "node ./scripts/check-commit-mail.js" "node ./scripts/cypress/component-check.js" "node ./scripts/angular-module-component-check.js" "npx validate-branch-name"
 echo "### lint staged files ###"
-npx --no -- lint-staged
-echo "### npm run lint ###"
-npx --no -- concurrently "node ./scripts/check-commit-mail.js" "node ./scripts/cypress/component-check.js" "node ./scripts/angular-module-component-check.js" "npm run lint:eslint" "npx validate-branch-name"
-
-
-
-
-
-
-
+lint-staged
+prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+git update-index --again

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
   "*.md": "markdownlint -c .markdown-lint.yml",
   "*.{css,scss}": "stylelint --fix",
-  "*": "prettier --write --ignore-unknown"
+  "*.{js,ts,tsx}": "eslint --fix "
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-plugin-storybook": "0.8.0",
         "eslint-plugin-vue": "^9.24.0",
         "find-versions-cli": "^5.0.0",
-        "husky": "9.0.11",
+        "husky": "9.1.2",
         "iframe-resizer": "4.4.5",
         "jest-config": "29.7.0",
         "lint-staged": "^15.2.2",
@@ -25943,12 +25943,12 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.2.tgz",
+      "integrity": "sha512-1/aDMXZdhr1VdJJTLt6e7BipM0Jd9qkpubPiIplon1WmCeOy3nnzsCMeBqS9AsL5ioonl8F8y/F2CLOmk19/Pw==",
       "dev": true,
       "bin": {
-        "husky": "bin.mjs"
+        "husky": "bin.js"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-storybook": "0.8.0",
     "eslint-plugin-vue": "^9.24.0",
     "find-versions-cli": "^5.0.0",
-    "husky": "9.0.11",
+    "husky": "9.1.2",
     "iframe-resizer": "4.4.5",
     "jest-config": "29.7.0",
     "lint-staged": "^15.2.2",


### PR DESCRIPTION
- adapted files to change out of https://github.com/db-ui/mono/pull/2882
- `pre-commit` git hook executed an repository wide `eslint` – we should scope this to the lint-staged files even only