### PR TITLE
refactor: simplification

### DIFF
--- a/.github/workflows/99-update-browserslist-database.yml
+++ b/.github/workflows/99-update-browserslist-database.yml
@@ -27,11 +27,10 @@ jobs:
       - name: Update Browserslist database
         run: npx update-browserslist-db@latest
 
-      - name: Set committer email
-        run: echo "COMMIT_MAIL=41898282+github-actions[bot]@users.noreply.github.com" >> .env
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
+        env:
+          HUSKY: 0 # Disable Husky hooks in CI
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update Browserslist database'


### PR DESCRIPTION
we'd like to simplify our code regarding the `husky` usage in the pipeline. We won't need it for the commit of a browserlist update, but only for localhost QA.