### PR TITLE
fix: trufflehog

### DIFF
--- a/.github/workflows/00-scan-secrets.yml
+++ b/.github/workflows/00-scan-secrets.yml
@@ -12,17 +12,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ↔ Extract branch name
-        uses: ./.github/actions/extract-branch
-        id: extract_branch
-
       - name: 🐷 TruffleHog OSS
         uses: trufflesecurity/trufflehog@main
         if: ${{ github.event.pull_request != null }} # only scan on pull-requests
         with:
-          path: ./
-          base: ${{ steps.extract_branch.outputs.branch-name }}
-          head: HEAD
+          # Setting base to an empty string scans the entire branch, per TruffleHog OSS advanced usage:
+          # https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch
+          base: ""
+          head: ${{ github.ref_name }}
+          extra_args: --results=verified,unknown
 
       - name: 💀 Killing me softly
         uses: ./.github/actions/cancel-workflow


### PR DESCRIPTION
According to trufflehogs documentation, to scan an entire branch, it's only necessary to provide some simple configuration: https://github.com/marketplace/actions/trufflehog-oss#advanced-usage-scan-entire-branch