### PR TITLE
refactor: Update condition to exclude all bots from assignment

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-add-assignees@v1
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ !contains(github.actor,'[bot]') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           assignees: ${{ github.actor }}


### PR DESCRIPTION
Exclude bot accounts in general, as they are not assignable (automatically).